### PR TITLE
Ignore socket.io calls when using with can-wait

### DIFF
--- a/io.js
+++ b/io.js
@@ -1,4 +1,5 @@
 var io = require("socket.io-client/socket.io");
+var ignore = require("can-wait/ignore");
 
 // In the server socket.io-client/socket.io is mapped to @empty
 // so we'll stub it as minimally as possible.
@@ -10,6 +11,8 @@ if(typeof io !== "function") {
 			off: noop
 		};
 	};
+} else {
+	io = ignore(io);
 }
 
 module.exports = io;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "testee": "^0.2.1"
   },
   "dependencies": {
+    "can-wait": "^0.2.5",
     "socket.io-client": "^1.3.7"
   },
   "system": {
@@ -49,7 +50,8 @@
     },
     "npmDependencies": [
       "socket.io-client",
-      "steal-qunit"
+      "steal-qunit",
+      "can-wait"
     ]
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,24 @@
 var io = require("steal-socket.io");
 var QUnit = require("steal-qunit");
+var wait = require("can-wait");
 
 QUnit.module("basics");
 
 QUnit.test("io is a function", function(){
 	QUnit.equal(typeof io, "function", "io is a function");
+});
+
+QUnit.test("works with can-wait", function(){
+	wait(function(){
+		setTimeout(function(){
+			var socket = io("http://chat.donejs.com");
+
+			QUnit.equal(typeof socket, "object", "got our socket back");
+		});
+	}).then(function(){
+		QUnit.ok("it completed");
+	})
+	.then(QUnit.start);
+
+	QUnit.stop();
 });


### PR DESCRIPTION
This fixes this scenario:

```js
wait(function(){
	io('http://chat.donejs.com');
}).then(function(){
	// never is called
});
```

We don't really want to wait on any socket.io stuff, so we simply ignore
its calls.