### PR TITLE
Use can-zone

### DIFF
--- a/io.js
+++ b/io.js
@@ -1,5 +1,5 @@
 var io = require("socket.io-client/socket.io");
-var ignore = require("can-wait/ignore");
+var Zone = require("can-zone");
 
 // In the server socket.io-client/socket.io is mapped to @empty
 // so we'll stub it as minimally as possible.
@@ -12,7 +12,7 @@ if(typeof io !== "function") {
 		};
 	};
 } else {
-	io = ignore(io);
+	io = Zone.ignore(io);
 }
 
 module.exports = io;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "testee": "^0.2.1"
   },
   "dependencies": {
-    "can-wait": "^0.2.5",
+    "can-zone": "^0.4.5",
     "socket.io-client": "^1.3.7"
   },
   "system": {
@@ -51,7 +51,7 @@
     "npmDependencies": [
       "socket.io-client",
       "steal-qunit",
-      "can-wait"
+      "can-zone"
     ]
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 var io = require("steal-socket.io");
 var QUnit = require("steal-qunit");
-var wait = require("can-wait");
+var Zone = require("can-zone");
 
 QUnit.module("basics");
 
@@ -9,7 +9,7 @@ QUnit.test("io is a function", function(){
 });
 
 QUnit.test("works with can-wait", function(){
-	wait(function(){
+	new Zone().run(function(){
 		setTimeout(function(){
 			var socket = io("http://chat.donejs.com");
 


### PR DESCRIPTION
This updates the library to depend on can-zone rather than the
deprecated can-wait. This will be a breaking change.