### PR TITLE
Store & expose the socket URL

### DIFF
--- a/delay-io.js
+++ b/delay-io.js
@@ -119,7 +119,7 @@ var DEBUG = false;
  * @returns {{on: function, emit: function, ...}}
  */
 function delayedSocket(fifoSocket){
-	return ['on', 'off', 'once', 'emit'].reduce(function(acc, method){
+	var base = ['on', 'off', 'once', 'emit'].reduce(function(acc, method){
 		acc[method] = function(){
 			var realSocket = fifoSocket.realSocket;
 			var fifo = fifoSocket.fifo;
@@ -134,6 +134,10 @@ function delayedSocket(fifoSocket){
 		};
 		return acc;
 	}, {});
+	base.io = {
+		uri: fifoSocket.url
+	}
+	return base;
 }
 
 /*

--- a/io.js
+++ b/io.js
@@ -21,11 +21,14 @@ var delayIO = require("./delay-io");
 // so we'll stub it as minimally as possible.
 if(typeof io !== "function") {
 	var noop = function(){};
-	io = function(){
+	io = function(uri){
 		return {
 			on: noop,
 			once: noop,
-			off: noop
+			off: noop,
+			io: {
+				uri: uri
+			}
 		};
 	};
 } else {

--- a/test/test.js
+++ b/test/test.js
@@ -39,3 +39,10 @@ QUnit.test("delay-io: test a module with early socket connection ", function(ass
 		done();
 	});
 });
+
+QUnit.test("emulates uri storage", function(){
+	var url = 'http://localhost:3030';
+	var socket = io(url);
+	console.log(socket);
+	QUnit.equal(socket.io.uri, url, "exposes the url at the same location as the Socket.io Manager class");
+});

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,7 @@ QUnit.test("delay-io: test a module with early socket connection ", function(ass
 	});
 });
 
-QUnit.test("emulates uri storage", function(){
+QUnit.test("emulates uri location", function(){
 	var url = 'http://localhost:3030';
 	var socket = io(url);
 	console.log(socket);

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,5 @@ QUnit.test("delay-io: test a module with early socket connection ", function(ass
 QUnit.test("emulates uri location", function(){
 	var url = 'http://localhost:3030';
 	var socket = io(url);
-	console.log(socket);
 	QUnit.equal(socket.io.uri, url, "exposes the url at the same location as the Socket.io Manager class");
 });


### PR DESCRIPTION
This makes the URL available externally to the socket, the way it is with actual socket.io-client.

```js
var socket = io(‘http://localhost:3030’);

assert(socket.io.uri === ‘http://localhost:3030’) // <— true
```