### PR TITLE
require steal before using steal.done() for SSR

### DIFF
--- a/delay-io.js
+++ b/delay-io.js
@@ -78,6 +78,7 @@
  * ```
  */
 
+var steal = require("@steal");
 module.exports = delayIO;
 
 /*


### PR DESCRIPTION
fixes issue with SSR when we use `steal.done()`
Ref: https://github.com/donejs/done-ssr/issues/194