### PR TITLE
Socketio dist update

### DIFF
--- a/delay-io.js
+++ b/delay-io.js
@@ -16,12 +16,12 @@
  *
  * ```
  * var delayIO = require("steal-socket.io/delay-io");
- * var socketIO = require("socket.io-client/socket.io");
+ * var socketIO = require("socket.io-client/dist/socket.io");
  * var io  = delayIO( socketIO );
  *
  * io("localhost");
  * ```
- *   @param {module} io The SocketIO client module. Usually, it is `socket.io-client/socket.io`.
+ *   @param {module} io The SocketIO client module. Usually, it is `socket.io-client/dist/socket.io`.
  *
  * @body
  *
@@ -41,7 +41,7 @@
  * to use just this wrapper.
  *
  * Lets say we have an application `myApp.js` that uses `socket.io` and tries to establish the connection right during
- * module evaluation. We import `steal-socket.io` in our app instead of `socket.io-client/socket.io`:
+ * module evaluation. We import `steal-socket.io` in our app instead of `socket.io-client/dist/socket.io`:
  * ```
  * var io = require("steal-socket.io");
  *
@@ -59,7 +59,7 @@
  *
  * We now create a module `myFixtureSocket.js` that mocks `socket.io` server responses, e.g. using `can-fixture-socket`:
  * ```
- * var io = require("socket.io-client/socket.io");
+ * var io = require("socket.io-client/dist/socket.io");
  * var fixtureSocket = require("can-fixture-socket");
  * var mockSocket = new fixtureSocket( io );
  * mockSocket.on("connect", function(){

--- a/ignore-zone.js
+++ b/ignore-zone.js
@@ -15,12 +15,12 @@
  *
  * ```
  * var ignoreZone = require("steal-socket.io/ignore-zone");
- * var socketIO = require("socket.io-client/socket.io");
+ * var socketIO = require("socket.io-client/dist/socket.io");
  * var io  = ignoreZone( socketIO );
  *
  * io("localhost");
  * ```
- *   @param {module} io The SocketIO client module. Usually, it is `socket.io-client/socket.io`.
+ *   @param {module} io The SocketIO client module. Usually, it is `socket.io-client/dist/socket.io`.
  */
 
 module.exports = function(io){

--- a/io.js
+++ b/io.js
@@ -9,15 +9,15 @@
  * @body
  *
  * This wrapper serves a purpose of ignoring socket-io during server-side rendereing (SSR). When usign [StealJS](http://stealjs.com/) as
- * a module loader this module maps `socket.io-client/socket.io` to an `@empty` module, and stubs `socket.io` as
+ * a module loader this module maps `socket.io-client/dist/socket.io` to an `@empty` module, and stubs `socket.io` as
  * minimally as possible.
  */
 
-var io = require("socket.io-client");
+var io = require("socket.io-client/dist/socket.io");
 var ignore = require("./ignore-zone");
 var delayIO = require("./delay-io");
 
-// In the server socket.io-client/socket.io is mapped to @empty
+// In the server socket.io-client/dist/socket.io is mapped to @empty
 // so we'll stub it as minimally as possible.
 if(typeof io !== "function") {
 	var noop = function(){};

--- a/package.json
+++ b/package.json
@@ -38,13 +38,19 @@
     "envs": {
       "server-development": {
         "map": {
-          "socket.io-client": "@empty"
+          "socket.io-client/dist/socket.io": "@empty"
         }
       },
       "server-production": {
         "map": {
-          "socket.io-client": "@empty"
+          "socket.io-client/dist/socket.io": "@empty"
         }
+      }
+    },
+    "meta": {
+      "socket.io-client/dist/socket.io": {
+        "format": "global",
+        "exports": "io"
       }
     },
     "npmDependencies": [

--- a/steal-socket.io.md
+++ b/steal-socket.io.md
@@ -36,7 +36,7 @@ var socket = io("localhost", {transports: ["websocket"]});
 If your application uses real-time communication with `socket.io` and your server supports SSR then its a good idea
 to ignore `socket.io` module during SSR completely.
 
-The `steal-socket.io` module maps `socket.io-client/socket.io` to an `@empty` module, and stubs `socket.io` as minimally
+The `steal-socket.io` module maps `socket.io-client/dist/socket.io` to an `@empty` module, and stubs `socket.io` as minimally
 as possible.
 
 ## Ignore can-zone
@@ -72,7 +72,7 @@ Import `steal-socket.io` which includes this wrapper as its part, or directly im
 to use just this wrapper.
 
 Lets say we have an application `myApp.js` that uses `socket.io` and tries to establish the connection right during
-module evaluation. We import `steal-socket.io` in our app instead of `socket.io-client/socket.io`:
+module evaluation. We import `steal-socket.io` in our app instead of `socket.io-client/dist/socket.io`:
 ```
 var io = require("steal-socket.io");
 
@@ -90,7 +90,7 @@ module.exports = {
 
 We now create a module `myFixtureSocket.js` that mocks `socket.io` server responses, e.g. using [can-fixture-socket](http://v3.canjs.com/doc/can-fixture-socket.html):
 ```
-var io = require("socket.io-client");
+var io = require("socket.io-client/dist/socket.io");
 var fixtureSocket = require("can-fixture-socket");
 var mockSocket = new fixtureSocket( io );
 mockSocket.on("connect", function(){

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ var Zone = require("can-zone");
 var myModel = require("./test-model");
 
 // Mock socket.io server to test socket events:
-var socketIO = require("socket.io-client");
+var socketIO = require("socket.io-client/dist/socket.io");
 var fixtureSocket = require("can-fixture-socket");
 var mockedServer = new fixtureSocket.Server( socketIO );
 mockedServer.on("message create", function(){


### PR DESCRIPTION
This updates the package.json to use the new dist location for socket.io-client.  Everything that used to refer to `socket.io-client/socket.io` now is updated to `socket.io-client/dist/socket.io`